### PR TITLE
Updated API caller file title in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ YT_API_KEY = "h5UYdzJHeZNWLTgGteh0J68k7icp9jp9vPJlbzF"
 
 ## Script Explanations
 
-### apis.py
+### APIHandler.py
 This class contains static methods to handle all API request for the Twitch and YouTube API.
 
 ### clip.py


### PR DESCRIPTION
Probably after renaming the file, it has been forgotten to rename it in the README.