### PR TITLE
Remove old artefact 'descriptions_dir'

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ There are a few additional steps depending on the operating system that are list
 CLIENT_ID = "o42tebpdzmj5z811iycgcpmd82on24"
 CLIENT_SECRET = "owdgx64t1dodleiuo49e5rg7rvk5iq"
 
-DIRECTORIES = dict(raw_clips_dir="rawClips", compilation_dir="compilation", descriptions_dir="descriptions")
+DIRECTORIES = dict(raw_clips_dir="rawClips", compilation_dir="compilation")
 
 # For the YouTube API
 # Optional: Only required if you want continuous numbering (e.g. Example Video Title #1, #2, ..., #N) for your videos

--- a/config.py
+++ b/config.py
@@ -2,7 +2,7 @@
 CLIENT_ID = "INSERT CLIENT_ID HERE"
 CLIENT_SECRET = "INSERT CLIENT_SECRET HERE"
 
-DIRECTORIES = dict(raw_clips_dir="rawClips", compilation_dir="compilation", descriptions_dir="descriptions")
+DIRECTORIES = dict(raw_clips_dir="rawClips", compilation_dir="compilation")
 
 # For the YouTube API
 # Optional: Only required if you want continuous numbering (e.g. Example Video Title #1, #2, ..., #N) for your videos

--- a/src/MetadataHandler.py
+++ b/src/MetadataHandler.py
@@ -19,7 +19,6 @@ class MetadataHandler:
         self.output_path = output_path
         self.game = game
         self.asset_path = asset_path
-        self.descriptions_dir = utils.get_game_path(config.DIRECTORIES["descriptions_dir"], self.game, output_path)
         self.compilation_dir = utils.get_game_path(config.DIRECTORIES["compilation_dir"], self.game, output_path)
         self.raw_clips_dir = utils.get_game_path(config.DIRECTORIES["raw_clips_dir"], self.game, output_path)
         self.metadata_config = None
@@ -71,11 +70,6 @@ class MetadataHandler:
 
     def get_youtube_description(self) -> str:
         return utils.load_txt_file(os.path.join(self.compilation_dir, "description_yt.txt"))
-
-    def get_instagram_description(self, clip: Clip) -> str:
-        return utils.load_txt_file(
-            os.path.join(self.descriptions_dir, utils.get_valid_file_name(f"{str(clip.clip_id)}{clip.id}.txt"))
-        )
 
     def get_youtube_title(self) -> str:
         return utils.load_txt_file(os.path.join(self.compilation_dir, "title_yt.txt"))


### PR DESCRIPTION
As discussed in the call, 'descriptions_dir' is not used anymore. This PR removes all remaining artifacts. No review required.